### PR TITLE
Adding docker dependency from the prefect server to the postgres DB

### DIFF
--- a/chaos-duck/Dockerfile
+++ b/chaos-duck/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.1 as production
+FROM python:3.12.1 AS production
 
 # Clone prefect to a global directory so we can install editably from there; later, in
 # docker-compose, we can mount your local prefect repo here to test local changes.  It's
@@ -15,7 +15,7 @@ RUN pip install -e /prefect/
 WORKDIR /app
 COPY ./chaos_duck /app/chaos_duck
 
-FROM production as testing
+FROM production AS testing
 
 COPY requirements-dev.txt /tmp/requirements-dev.txt
 RUN pip install -r /tmp/requirements-dev.txt

--- a/chaos-duck/docker-compose.yaml
+++ b/chaos-duck/docker-compose.yaml
@@ -23,6 +23,8 @@ services:
     volumes:
       - prefect-data:/data
       - .:/app
+    depends_on:
+      - postgres
   tasks:
     deploy:
       replicas: 8

--- a/chaos-duck/requirements-dev.txt
+++ b/chaos-duck/requirements-dev.txt
@@ -45,7 +45,6 @@ attrs==23.2.0
 cachetools==5.3.3
     # via
     #   -r requirements.txt
-    #   google-auth
     #   prefect
 certifi==2024.2.2
     # via
@@ -53,7 +52,6 @@ certifi==2024.2.2
     #   apprise
     #   httpcore
     #   httpx
-    #   kubernetes
     #   requests
 cffi==1.16.0
     # via
@@ -128,10 +126,6 @@ fsspec==2024.2.0
     # via
     #   -r requirements.txt
     #   prefect
-google-auth==2.28.2
-    # via
-    #   -r requirements.txt
-    #   kubernetes
 graphviz==0.20.1
     # via
     #   -r requirements.txt
@@ -225,10 +219,6 @@ jsonschema-specifications==2023.12.1
     # via
     #   -r requirements.txt
     #   jsonschema
-kubernetes==29.0.0
-    # via
-    #   -r requirements.txt
-    #   prefect
 mako==1.3.2
     # via
     #   -r requirements.txt
@@ -255,7 +245,6 @@ mdurl==0.1.2
 oauthlib==3.2.2
     # via
     #   -r requirements.txt
-    #   kubernetes
     #   requests-oauthlib
 orjson==3.9.15
     # via
@@ -282,7 +271,7 @@ pexpect==4.9.0
     # via ipython
 pluggy==1.4.0
     # via pytest
-prefect==3.0.0rc2
+prefect==3.0.0rc13
     # via -r requirements.txt
 prompt-toolkit==3.0.43
     # via ipython
@@ -290,15 +279,6 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.5.1
-    # via
-    #   -r requirements.txt
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.3.0
-    # via
-    #   -r requirements.txt
-    #   google-auth
 pycparser==2.21
     # via
     #   -r requirements.txt
@@ -315,7 +295,7 @@ pydantic-core==2.18.4
     #   -r requirements.txt
     #   prefect
     #   pydantic
-pydantic-extra-types==2.8.1
+pydantic-extra-types==2.9.0
     # via
     #   -r requirements.txt
     #   prefect
@@ -345,7 +325,6 @@ python-dateutil==2.9.0.post0
     #   -r requirements.txt
     #   croniter
     #   dateparser
-    #   kubernetes
     #   pendulum
     #   prefect
     #   time-machine
@@ -372,7 +351,6 @@ pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   apprise
-    #   kubernetes
     #   prefect
     #   uvicorn
 readchar==4.0.5
@@ -393,13 +371,11 @@ requests==2.31.0
     #   -r requirements.txt
     #   apprise
     #   docker
-    #   kubernetes
     #   requests-oauthlib
 requests-oauthlib==1.4.0
     # via
     #   -r requirements.txt
     #   apprise
-    #   kubernetes
 rfc3339-validator==0.1.4
     # via
     #   -r requirements.txt
@@ -414,10 +390,6 @@ rpds-py==0.18.0
     #   -r requirements.txt
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via
-    #   -r requirements.txt
-    #   google-auth
 ruamel-yaml==0.18.6
     # via
     #   -r requirements.txt
@@ -436,7 +408,6 @@ six==1.16.0
     # via
     #   -r requirements.txt
     #   asttokens
-    #   kubernetes
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
@@ -507,7 +478,6 @@ urllib3==2.2.1
     # via
     #   -r requirements.txt
     #   docker
-    #   kubernetes
     #   requests
 uvicorn[standard]==0.28.0
     # via
@@ -529,12 +499,15 @@ websocket-client==1.7.0
     # via
     #   -r requirements.txt
     #   docker
-    #   kubernetes
 websockets==12.0
     # via
     #   -r requirements.txt
     #   prefect
     #   uvicorn
+wrapt==1.16.0
+    # via
+    #   -r requirements.txt
+    #   prefect
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/chaos-duck/requirements.in
+++ b/chaos-duck/requirements.in
@@ -1,2 +1,2 @@
-prefect>=3rc2
+prefect>=3rc13
 docker

--- a/chaos-duck/requirements.txt
+++ b/chaos-duck/requirements.txt
@@ -27,15 +27,12 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
 cachetools==5.3.3
-    # via
-    #   google-auth
-    #   prefect
+    # via prefect
 certifi==2024.2.2
     # via
     #   apprise
     #   httpcore
     #   httpx
-    #   kubernetes
     #   requests
 cffi==1.16.0
     # via cryptography
@@ -75,8 +72,6 @@ fastapi-cli==0.0.4
     # via fastapi
 fsspec==2024.2.0
     # via prefect
-google-auth==2.28.2
-    # via kubernetes
 graphviz==0.20.1
     # via prefect
 greenlet==3.0.3
@@ -131,8 +126,6 @@ jsonschema==4.21.1
     # via prefect
 jsonschema-specifications==2023.12.1
     # via jsonschema
-kubernetes==29.0.0
-    # via prefect
 mako==1.3.2
     # via alembic
 markdown==3.5.2
@@ -146,9 +139,7 @@ markupsafe==2.1.5
 mdurl==0.1.2
     # via markdown-it-py
 oauthlib==3.2.2
-    # via
-    #   kubernetes
-    #   requests-oauthlib
+    # via requests-oauthlib
 orjson==3.9.15
     # via
     #   fastapi
@@ -161,14 +152,8 @@ pathspec==0.12.1
     # via prefect
 pendulum==3.0.0
     # via prefect
-prefect==3.0.0rc2
+prefect==3.0.0rc13
     # via -r requirements.in
-pyasn1==0.5.1
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.3.0
-    # via google-auth
 pycparser==2.21
     # via cffi
 pydantic==2.7.4
@@ -181,7 +166,7 @@ pydantic-core==2.18.4
     # via
     #   prefect
     #   pydantic
-pydantic-extra-types==2.8.1
+pydantic-extra-types==2.9.0
     # via prefect
 pydantic-settings==2.3.3
     # via prefect
@@ -191,7 +176,6 @@ python-dateutil==2.9.0.post0
     # via
     #   croniter
     #   dateparser
-    #   kubernetes
     #   pendulum
     #   prefect
     #   time-machine
@@ -211,7 +195,6 @@ pytz==2024.1
 pyyaml==6.0.1
     # via
     #   apprise
-    #   kubernetes
     #   prefect
     #   uvicorn
 readchar==4.0.5
@@ -226,12 +209,9 @@ requests==2.31.0
     # via
     #   apprise
     #   docker
-    #   kubernetes
     #   requests-oauthlib
 requests-oauthlib==1.4.0
-    # via
-    #   apprise
-    #   kubernetes
+    # via apprise
 rfc3339-validator==0.1.4
     # via prefect
 rich==13.7.1
@@ -242,8 +222,6 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via google-auth
 ruamel-yaml==0.18.6
     # via prefect
 ruamel-yaml-clib==0.2.8
@@ -252,7 +230,6 @@ shellingham==1.5.4
     # via typer
 six==1.16.0
     # via
-    #   kubernetes
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
@@ -299,7 +276,6 @@ ujson==5.9.0
 urllib3==2.2.1
     # via
     #   docker
-    #   kubernetes
     #   requests
 uvicorn[standard]==0.28.0
     # via
@@ -310,13 +286,13 @@ uvloop==0.19.0
 watchfiles==0.22.0
     # via uvicorn
 websocket-client==1.7.0
-    # via
-    #   docker
-    #   kubernetes
+    # via docker
 websockets==12.0
     # via
     #   prefect
     #   uvicorn
+wrapt==1.16.0
+    # via prefect
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
As I was using chaos duck to test some aspects of client-side task run
orchestration, I noticed that the prefect server here didn't depend on the
DB.  I also touched up a couple other warnings in the Dockerfile.
